### PR TITLE
fix compatibility with bitbucketcloud

### DIFF
--- a/charts/jx-slack/templates/deployment.yaml
+++ b/charts/jx-slack/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
           value: "{{ .Values.jxRequirements.cluster.gitKind }}"
         - name: GIT_SECRET_SERVER
           value: "{{ .Values.jxRequirements.cluster.gitServer }}"
+        - name: GIT_SERVER
+          value: "{{ .Values.jxRequirements.cluster.gitServer }}"
+{{- if eq .Values.jxRequirements.cluster.gitKind "bitbucketcloud" }}
+        - name: GIT_USER
+          value: "{{ .Values.jxRequirements.pipelineUser.username }}"
+{{- end }}
         - name: GIT_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
In order to use this chart with `bitbucketcloud`, one must provide `GIT_USER` environment variable. Here we're using the pipeline user as that user.

Fixes the following error:

```
error: failed to validate options: failed to create SCM client: no username supplied
using driver: bitbucketcloud and serverURL: 
```